### PR TITLE
Менше споживання RAM від MySQL для локальної розробки

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
     restart: always
     ports:
       - "33061:3306"
+    command: |-
+      --performance_schema=0
+      --innodb_buffer_pool_size=32M
+      --key_buffer_size=8M
+      --query_cache_size=0
     volumes:
       - mysql:/var/lib/mysql
       - ./install/sql/mysql.sql:/docker-entrypoint-initdb.d/mysql.sql


### PR DESCRIPTION
Мінімальне споживання:
Було: 110 МБ
Стало: 70 МБ

Максимальне:
Було: >400 МБ
Стало: ~200 МБ

Для production такі налаштування не підходять, але для локальної рохробки, де база дуже мала і швидкість менш важлива, ніж споживання ресурсів - це оптимально.